### PR TITLE
changed barnard59 dependency URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -195,8 +195,8 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "barnard59": {
-      "version": "git+https://github.com/zazuko/barnard59.git#fe4401598f7a174958753ea5b0c8323c01ab0702",
-      "from": "git+https://github.com/zazuko/barnard59.git#master",
+      "version": "git+https://github.com/zazuko/barnard59-legacy.git#fe4401598f7a174958753ea5b0c8323c01ab0702",
+      "from": "git+https://github.com/zazuko/barnard59-legacy.git#master",
       "requires": {
         "JSONStream": "^1.3.1",
         "bluebird": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git@github.com:statistikstadtzuerich/statabs-data.git"
   },
   "dependencies": {
-    "barnard59": "git+https://github.com/zazuko/barnard59.git#master",
+    "barnard59": "git+https://github.com/zazuko/barnard59-legacy.git#master",
     "bluebird": "^3.5.1",
     "duplexify": "^3.6.0",
     "ftp": "^0.3.10",


### PR DESCRIPTION
We would like to replace the current barnard59 repository with the new implementation of the pipeline. This requires to change URL of the dependency in projects using the legacy package.